### PR TITLE
Saveit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,11 @@ READIT
 
 `readit` is a Python enabled Stata package to read and append multiple files quickly and easily.  
 
+## Installation
+Install the package from GitHub
+
+>>> net install readit, from(https://raw.github.com/wbuchanan/readit/master/)
+
 
 ## Usage
 

--- a/readit.ado
+++ b/readit.ado
@@ -497,7 +497,8 @@ class ReadIt(object):
         :param dfs: A list of pandas.DataFrame objects that will be appended to form a single data set.
         """
         # Appends all of the data into a single pd.DataFrame object
-        self.data = pd.concat(dfs, axis=0, join = 'inner', ignore_index=True, sort=True)
+        sort = len(dfs) > 1
+        self.data = pd.concat(dfs, axis=0, join = 'inner', ignore_index=True, sort=sort)
         # Trying to replace missing values with a similar missing type
         #self.data.fillna(value=np.nan, axis=1, inplace=True)
 

--- a/readit.ado
+++ b/readit.ado
@@ -98,8 +98,10 @@ from pandas import read_stata, \
     read_feather, \
     read_parquet, \
     read_hdf
-from pandas.io.json import json_normalize
-
+try:
+    from pandas.io.json import json_normalize  # old location
+except:
+    from pandas import json_normalize
 
 
 class ReadIt(object):

--- a/readit.do
+++ b/readit.do
@@ -22,7 +22,10 @@ from pandas import read_stata, \
     read_feather, \
     read_parquet, \
     read_hdf
-from pandas.io.json import json_normalize
+try:
+    from pandas.io.json import json_normalize  # old location
+except:
+    from pandas import json_normalize
 
 
 

--- a/readit.pkg
+++ b/readit.pkg
@@ -15,6 +15,8 @@ d KW: data munging
 d
 d Requires: Stata version 16
 d
+d Distribution-Date: 20200727
+d
 d Author: Billy Buchanan
 d                 Director
 d                 Office of Grants, Research, Accountability, & Data
@@ -25,5 +27,4 @@ d Support: email billy [dot] buchanan [at] fayette.kyschools.us
 d
 f readit.ado
 f readit.sthlp
-
 

--- a/readit/ReadIt.py
+++ b/readit/ReadIt.py
@@ -19,7 +19,10 @@ from pandas import read_stata, \
     read_feather, \
     read_parquet, \
     read_hdf
-from pandas.io.json import json_normalize
+try:
+    from pandas.io.json import json_normalize
+except:
+    from pandas import json_normalize
 
 
 

--- a/readit/saveit.do
+++ b/readit/saveit.do
@@ -1,0 +1,12 @@
+*python set exec ....
+program drop _all
+
+sysuse auto, clear
+describe
+datasignature
+saveit auto.parquet, replace
+
+readit "'auto.parquet'", clear
+describe
+datasignature
+

--- a/readit/utilities/validator.py
+++ b/readit/utilities/validator.py
@@ -13,7 +13,10 @@ from pandas import read_stata, \
     read_feather, \
     read_parquet, \
     read_hdf
-from pandas.io.json import json_normalize
+try:
+    from pandas.io.json import json_normalize  # old location
+except:
+    from pandas import json_normalize
 
 PANDAS_IO = [ read_stata, read_csv, read_excel, read_spss, read_sas,
               read_html, read_pickle, read_table, read_json, read_fwf,

--- a/saveit.ado
+++ b/saveit.ado
@@ -1,0 +1,75 @@
+// For now, just saves files in parquet format. Later make more general
+// Usage: saveit auto.parquet, replace
+
+//TODO: Test using both parquet engines
+program saveit
+    syntax anything [, replace]
+
+    if "`replace'"=="" {
+        cap confirm file `anything'
+        _assert(_rc!=0), msg("File already exists. You can specify -replace-")
+    }
+    //There's no way to use the Python API to query char keys, so in Stata store them as locals
+    //TODO: Throw warning if variables named _dta or anything
+    unab vlist : *
+    loc evlist _dta `vlist'
+    foreach ev in `evlist' {
+        loc `ev' : char `ev'[]
+    }
+
+    python: save_parquet("`anything'", ": data label")
+end
+
+python:
+from sfi import Characteristic, Data, ValueLabel, Macro, SFIToolkit
+import pandas as pd
+import numpy as np
+
+types_stata_to_pandas = {'byte':pd.Int8Dtype(), 'int':pd.Int16Dtype(), 'long':pd.Int32Dtype(), 'float':pd.Float32Dtype(), 'double':pd.Float64Dtype()}
+
+def get_stata_metadata(vars : [str], data_label: str = ""):
+    var_types = {}
+    var_meta = {}
+    var_chars = {}
+    for var in vars:
+        var_type = Data.getVarType(var)
+        # If str, just store length
+        if Data.isVarTypeStr(var):
+            var_type = int(var_type[3:])
+        var_types[var] = var_type
+        
+        var_meta[var] = (Data.getVarLabel(var), Data.getVarFormat(var), ValueLabel.getVarValueLabel(var))
+        
+        var_chars[var] = {name: Characteristic.getVariableChar(var, name) for name in Macro.getLocal(var).split(" ")}
+
+    dta_chars = {name: Characteristic.getDtaChar(name) for name in Macro.getLocal("_dta").split(" ")}
+        
+    vls = {}
+    for name in ValueLabel.getNames():
+        vls[name] = ValueLabel.getValueLabels(name) # (getLabels(var_label_name), getValues(var_label_name))
+
+    return {'vls': vls, 'var_types':var_types, 'var_meta':var_meta, 'data_label': data_label, 'dta_chars': dta_chars, 'var_chars': var_chars}
+
+def save_parquet(path: str, data_label:str = "", **kwargs):
+    
+    dataraw = Data.getAsDict(missingval=np.nan)
+    # TODO: ensure same order when using dict
+    vars = dataraw.keys()
+    stata_metadata = get_stata_metadata(vars, data_label)
+    
+    # ensure Stata integer types are mapped to pd nullable types, rather than float, and ensure float/double correct conversion
+    for var in vars:
+        v_type = stata_metadata['var_types'][var]
+        if Data.isVarTypeStr(var):
+            dataraw[var] = pd.array(dataraw[var], dtype=pd.StringDtype()) 
+        else:
+            dataraw[var] = pd.array(dataraw[var], dtype=types_stata_to_pandas[v_type])
+
+    
+    
+    dataframe = pd.DataFrame(dataraw)
+    dataframe.attrs = {'stata_metadata': stata_metadata} # since 2.1 https://github.com/pandas-dev/pandas/issues/54321
+
+    dataframe.to_parquet(path, **kwargs)
+
+end


### PR DESCRIPTION
Here's an initial version of `saveit.ado` that currently just saves to parquet format. Once we work things out, I'll make it more general. Also included are a few fixes for `readit` that I found while doing round-trip testing. You can see them in the separate commits. The two biggest are (a) fixing the storage of numerical missings (e.g., with a int variable that had a missing value, the old approach would cause `Data.store()` to upcast the Stata variable to a long and have the value of 32767), and (b) I made `saveit` store all potential Stata metadata, and now in `readit` we check to see if it's available and if so we restore it allow us to have exactly the same dataset back. For (b), I took a stab at refactoring this with your categorical code, but feel free to re-arrange. Stata value labels don't exactly map to pandas categicals because in Stata you don't have to label all values, so in `saveit` I currently don't try to convert variables to categoricals. 

Let me know what you think!