### PR TITLE
Full saveit implimentation

### DIFF
--- a/readit.ado
+++ b/readit.ado
@@ -441,9 +441,6 @@ class ReadIt(object):
         elif filetype == 'html':
             args = self._valid_args(kwargs, 'read_html')
             return pd.read_html(filenm, **args).convert_dtypes()
-        elif filetype == 'fwf':
-            args = self._valid_args(kwargs, 'read_sas')
-            return pd.read_sas(filenm, **args).convert_dtypes()
         elif filetype == 'pickle':
             args = self._valid_args(kwargs, 'read_pickle')
             return pd.read_pickle(filenm, **args).convert_dtypes()

--- a/readit.ado
+++ b/readit.ado
@@ -440,7 +440,7 @@ class ReadIt(object):
             return pd.read_sas(filenm, **args).convert_dtypes()
         elif filetype == 'html':
             args = self._valid_args(kwargs, 'read_html')
-            return pd.read_html(filenm, **args).convert_dtypes()
+            return pd.read_html(filenm, **args)[0].convert_dtypes()
         elif filetype == 'pickle':
             args = self._valid_args(kwargs, 'read_pickle')
             return pd.read_pickle(filenm, **args).convert_dtypes()

--- a/readit.ado
+++ b/readit.ado
@@ -122,7 +122,7 @@ class ReadIt(object):
         automatically.
         :param recursive: Indicates whether or not glob should search for the file name string recursively
         :param raw_json: A boolean used to determine which JSON parsing method to use when reading the data.  If True,
-        the class will use pandas.read_json() otherwise, a file object is passed to pandas.io.json.json_normalize()
+        the class will use pandas.read_json() otherwise, a file object is passed to pandas' json_normalize()
         :param kwargs: The optional keyword arguments that can be passed to the constructor are used to trigger behaviors
         of the pandas data parsers.  Passing keyword arguments here can be useful if you only want to retain a subset of
         the data from the files and the columns you wish to keep/exclude exist in all of the files.
@@ -457,7 +457,7 @@ class ReadIt(object):
             else:
                 args = self._valid_args(kwargs, 'json_normalize')
                 with open(filenm, 'r') as f:
-                    return pd.io.json.json_normalize(json.load(f.read()), **args).convert_dtypes()
+                    return json_normalize(json.load(f.read()), **args).convert_dtypes()
         elif filetype == 'fwf':
             args = self._valid_args(kwargs, 'read_fwf')
             return pd.read_fwf(filenm, **args).convert_dtypes()

--- a/readit/saveit.do
+++ b/readit/saveit.do
@@ -4,9 +4,45 @@ program drop _all
 sysuse auto, clear
 describe
 datasignature
-saveit auto.parquet, replace
+loc ds = r(datasignature)
 
-readit "'auto.parquet'", clear
-describe
-datasignature
+//to_hdf is fairly limited at this time, essentially a single numpy array (so homogeneous type and not our typical Pandas extension type with includes nulls for ints). Can't even get to work with a df of just 2 floats
+foreach ext in dta xls xlsx csv pkl json html feather parquet1 parquet2 /*h5*/ {
+	preserve
+	di "`ext'"
 
+	* Save file
+	loc save_opts = ""
+	if "`ext'"=="parquet1" {
+		loc ext "parquet"
+		loc save_options pd_options("engine='fastparquet'")
+	}
+	if "`ext'"=="parquet2" {
+		loc ext "parquet"
+		loc save_options pd_options("engine='pyarrow'")
+	}
+	if "`ext'"=="dta" drop make headroom gear_ratio //to_stata() doesn't support strings or float32 yet
+	if "`ext'"=="xls" loc save_opts pd_options("engine='openpyxl'")
+	saveit auto.`ext', replace 	`save_opts'
+
+	* Load file
+	loc read_opts = ""
+	if "`ext'"=="json" loc read_opts rawjson
+	readit "'auto.`ext''", clear `read_opts'
+	
+	* Compare
+	qui datasignature
+	loc ds2 = r(datasignature)
+	if "`ds'"!="`ds2'" {
+		di "failed"
+		describe
+		datasignature
+	}
+	else {
+		di "succeeded"
+	}
+	
+	* Cleanup
+	rm "auto.`ext'"
+	restore
+}

--- a/saveit.ado
+++ b/saveit.ado
@@ -1,7 +1,6 @@
-// For now, just saves files in parquet format. Later make more general
-// Usage: saveit auto.parquet, replace
-
-//TODO: Test using both parquet engines
+*! version 1.0.0.
+*! Saves files in multiple formats using Python's Pandas functionality.
+*! Usage: saveit auto.parquet, replace
 program saveit
     syntax anything [, REPlace Type(string) pd_options(string)]
 

--- a/saveit.sthlp
+++ b/saveit.sthlp
@@ -1,0 +1,110 @@
+{smcl}
+{* *! version 0.0.1 20jul2020}{...}
+{vieweralsosee "[D] save" "mansection D save"}{...}
+{vieweralsosee "" "--"}{...}
+{vieweralsosee "[D] export excel" "mansection D exportexcel"}{...}
+{vieweralsosee "[D] putexcel" "mansection D putexcel"}{...}
+{vieweralsosee "[D] export delimited" "mansection D exportdelimited"}{...}
+{vieweralsosee "[D] outfile" "mansection D outfile"}{...}
+{vieweralsosee "[D] export sasxport8" "mansection D exportsasxport8"}{...}
+{vieweralsosee "[D] export dbase" "mansection D exportdbase"}{...}
+{viewerjumpto "Syntax" "saveit##syntax"}{...}
+{viewerjumpto "Description" "saveit##description"}{...}
+{viewerjumpto "File Type Inference" "saveit##filetypes"}{...}
+{viewerjumpto "Options" "saveit##options"}{...}
+{viewerjumpto "Data Fidelity" "saveit##datafidelity"}{...}
+{viewerjumpto "Pandas" "saveit##pandas"}{...}
+{viewerjumpto "Examples" "saveit##examples"}{...}
+
+{marker syntax}{...}
+{title:Syntax}
+
+{p 8 32 2}
+{cmd:saveit} file [{cmd:,} {it:options}]{p_end}
+
+{p 4 4 2}The {cmd:saveit} command accepts a file path as the first argument. It then uses the the Python package Pandas to save the data in one of a variety of file formats, expanding the types of files that can saved from Stata. {p_end}
+
+{marker description}{...}
+{title:Description}
+
+{p 4 4 2}For all functionality to work correctly, {cmd: saveit} requires the 
+following Python packages to be installed:{p_end}
+{p2colset 8 24 24 8}
+{p2line}
+{p2col :{opt File types}}{opt Package}{p_end}
+{p2line}
+{p2col :{opt All}}pandas{p_end}
+{p2col :{opt Apache Arrow}}pyarrow{p_end}
+{p2col :{opt Apache Parquet}}fastparquet or pyarrow{p_end}
+{p2col :{opt Excel}}openpyxl or xlsxwriter{p_end}
+{p2line}
+
+{marker filetypes}{...}
+{title:File Type Inference}
+
+{p 4 4 2}{cmd:saveit}, by default, uses a mapping from file extensions to file types in order 
+to dispatch the appropriate I/O methods for a given file. (This can be overridden with the {it:type} option.){p_end}
+{p2colset 8 24 24 8}
+{p2line}
+{p2col :{opt Extension}}{opt File Type}{p_end}
+{p2line}
+{p2col :{opt .xls}}MS Excel{p_end}
+{p2col :{opt .xlsx}}MS Excel{p_end}
+{p2col :{opt .csv}}Comma Delimited{p_end}
+{p2col :{opt .pkl}}Pickle{p_end}
+{p2col :{opt .pickle}}Pickle{p_end}
+{p2col :{opt .json}}JSON{p_end}
+{p2col :{opt .html}}HTML{p_end}
+{p2col :{opt .feather}}Apache Arrow/Parquet{p_end}
+{p2col :{opt .parquet}}Parquet{p_end}
+{p2line}
+
+{marker options}{...}
+{title:Options}
+
+{synoptset 25 tabbed}{...}
+{synoptline}
+{synopthdr}
+{synoptline}
+{synopt :{opt t:ype}}Use this option if you want to explicitly specify the file type rather than use automatic inference based on file extensions.{p_end}
+{synopt :{opt rep:lace}}Optional argument to overwrite an existing file when using the {opt save} option.{p_end}
+{synopt :{opt pd_options}}See {help saveit##pandas:Pandas Options} for more info about using Pandas options.  {p_end}
+{synoptline}
+
+{marker datafidelity}{...}
+{title:Data Fidelity}
+
+{p 4 4 2}The conversion process to a Pandas DataFrame in memory and then to the file format on disk may convert some variable types and discard Stata metadata (e.g., variable labels, value labels, variable formats, dataset label, and dataset characterics). When converting to Pandas DataFrames, (1) all Stata string types are converted to a single generic string type, and (2) we store all Stata meta-data plus the original Stata variable types in the DataFrame's {it: .attrs} dictionary under the key 'stata_metadata'. (Note: we do not use Pandas categorical variables for variables with value labels as they are a bit more restrictive). Two file formats, pickle and parquet, can exactly store all the Pandas types and preserve this metatdata, which means that if we read that data back using a program that uses that metadata (e.g., {cmd: readit}), we will automatically convert string variables back to their original type and restore all metadata, ensuring the exact same dataset is restored. Other formats do not retain this metadata. Saving to the feather format can exactly store all the Pandas variable types, but does not store the metadata. Restoring a file will therefore not differentiate the string types. Other format additionally have more restrictive variable storage formats than Pandas. Saving to excel, csv, json, and html will convert all numerical variables to a generic floating point number and all string variables to a generic string type.
+
+{marker pandas}{...}
+{title:Pandas Options}
+{break}
+{p 8 4 2}Additional parameters can be passed to the Pandas I/O routines through {it: pd_options()}. For full information regarding the options available we recommend consulting the 
+references available here: {browse "https://pandas.pydata.org/pandas-docs/stable/reference/io.html":https://pandas.pydata.org/pandas-docs/stable/reference/io.html}.{p_end}
+
+{p 8 4 2}To use any of these options, enclose them in a single set of quotation 
+marks after all other options have been specified (note the comma between the two options below):  {p_end}
+
+{p 12 8 2}
+pd_options("sheet_name='auto', engine='openpyxl'")
+{p_end}
+
+{p 8 4 2}When specifying string arguments for parameters that will be passed on to the 
+Pandas I/O methods, use the apostrophe (i.e., right tick mark) to pass string 
+values.{p_end}
+
+
+{p 4 4 2}Note: {cmd:saveit} automatically specifies {it: index=False} for those file-types that accept that argument.  {p_end}
+
+
+{marker examples}{...}
+{title:Examples}
+
+{p 4 4 2}Save a parquet file:{p_end}
+
+{p 8 4 2}{hi:saveit auto.parquet, replace}{p_end}
+
+{p 4 4 2}Save an Excel file to a specific sheet using a particular engine.{p_end}
+
+{p 8 4 2}{hi:saveit auto.xls, replace pd_options("sheet_name='auto', engine='openpyxl'")}{p_end}
+


### PR DESCRIPTION
This PR completes a full `saveit` implementation. It also includes 3 small fixes for `readit`.

One thing to note, is that I handled extra arguments to Pandas a bit differently. Using the `readit` approach, specifying `engine='openpyxl'` would be automatically converted to `engine = ' openpyxl '`, which would cause problems in the pandas call. So, I just had the user pass in the final string. 